### PR TITLE
cgo: include stdbool

### DIFF
--- a/src/calculator.go
+++ b/src/calculator.go
@@ -5,6 +5,7 @@ package main
 #cgo CXXFLAGS: -std=c++11
 #cgo LDFLAGS: -lstdc++
 #include <stdlib.h>
+#include <stdbool.h>
 
 char* calculate_expression(const char* expression);
 void free_result(char* result);


### PR DESCRIPTION
`make build` was failing for me with this error:

```sh
cd src && go build -ldflags "-X main.version=v1.0.4" -o ../nasc
# nasc
./calculator.go:12:1: error: unknown type name 'bool'
   12 | bool update_exchange_rates_if_needed();
      | ^~~~
./calculator.go:8:1: note: 'bool' is defined in header '<stdbool.h>'; this is probably fixable by adding '#include <stdbool.h>'
    7 | #include <stdlib.h>
  +++ |+#include <stdbool.h>
    8 |
make: *** [Makefile:9: build] Error 1
```